### PR TITLE
Restore the previous LayerType value of View when using withLayer option

### DIFF
--- a/library/src/main/java/com/bartoszlipinski/viewpropertyobjectanimator/ViewPropertyObjectAnimator.java
+++ b/library/src/main/java/com/bartoszlipinski/viewpropertyobjectanimator/ViewPropertyObjectAnimator.java
@@ -807,17 +807,23 @@ public class ViewPropertyObjectAnimator {
                             holders.toArray(new PropertyValuesHolder[holders.size()]));
             if (mWithLayer) {
                 animator.addListener(new AnimatorListenerAdapter() {
+                    int currentLayerType = View.LAYER_TYPE_NONE;
                     @Override
                     public void onAnimationStart(Animator animation) {
                         if (hasView()) {
-                            mView.get().setLayerType(View.LAYER_TYPE_HARDWARE, null);
+                            View view = mView.get();
+                            currentLayerType = view.getLayerType();
+                            view.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+                            if(view.isAttachedToWindow()) {
+                                view.buildLayer();
+                            }
                         }
                     }
 
                     @Override
                     public void onAnimationEnd(Animator animation) {
                         if (hasView()) {
-                            mView.get().setLayerType(View.LAYER_TYPE_NONE, null);
+                            mView.get().setLayerType(currentLayerType, null);
                         }
                     }
                 });

--- a/library/src/main/java/com/bartoszlipinski/viewpropertyobjectanimator/ViewPropertyObjectAnimator.java
+++ b/library/src/main/java/com/bartoszlipinski/viewpropertyobjectanimator/ViewPropertyObjectAnimator.java
@@ -807,12 +807,12 @@ public class ViewPropertyObjectAnimator {
                             holders.toArray(new PropertyValuesHolder[holders.size()]));
             if (mWithLayer) {
                 animator.addListener(new AnimatorListenerAdapter() {
-                    int currentLayerType = View.LAYER_TYPE_NONE;
+                    int mCurrentLayerType = View.LAYER_TYPE_NONE;
                     @Override
                     public void onAnimationStart(Animator animation) {
                         if (hasView()) {
                             View view = mView.get();
-                            currentLayerType = view.getLayerType();
+                            mCurrentLayerType = view.getLayerType();
                             view.setLayerType(View.LAYER_TYPE_HARDWARE, null);
                             if(view.isAttachedToWindow()) {
                                 view.buildLayer();
@@ -823,7 +823,7 @@ public class ViewPropertyObjectAnimator {
                     @Override
                     public void onAnimationEnd(Animator animation) {
                         if (hasView()) {
-                            mView.get().setLayerType(currentLayerType, null);
+                            mView.get().setLayerType(mCurrentLayerType, null);
                         }
                     }
                 });


### PR DESCRIPTION
When using withLayer option the view's layer type is set to
LAYER_TYPE_NONE at the end of animation independently of original value
