### PR TITLE
Only run the withEndAction runnable if the animation isn't canceled

### DIFF
--- a/library/src/main/java/com/bartoszlipinski/viewpropertyobjectanimator/ViewPropertyObjectAnimator.java
+++ b/library/src/main/java/com/bartoszlipinski/viewpropertyobjectanimator/ViewPropertyObjectAnimator.java
@@ -786,9 +786,18 @@ public class ViewPropertyObjectAnimator {
 
     public ViewPropertyObjectAnimator withEndAction(final Runnable runnable) {
         return addListener(new AnimatorListenerAdapter() {
+            private boolean mIsCanceled;
+
+            @Override
+            public void onAnimationCancel(Animator animation) {
+                mIsCanceled = true;
+            }
+
             @Override
             public void onAnimationEnd(Animator animation) {
-                runnable.run();
+                if (!mIsCanceled) {
+                    runnable.run();
+                }
                 removeListener(this);
             }
         });


### PR DESCRIPTION
To stay close with ViewPropertyAnimator's behavior, if the ObjectAnimator is canceled during that animation, the runnable defined on withEndAction should not run.
